### PR TITLE
Add the id to items so we can look up individual item later

### DIFF
--- a/src/contentful-response-parser.js
+++ b/src/contentful-response-parser.js
@@ -12,6 +12,7 @@ export const generateItemObject = (data, assets = null, entries = null) => {
     }
     item[key] = fieldValue
   })
+  item.id = data.sys.id
   return item
 }
 
@@ -55,7 +56,12 @@ const resolveLink = (item, assets, entries) => {
   if (item.sys.linkType === 'Asset') {
     return assets[item.sys.id] || {}
   } else if (item.sys.linkType === 'Entry') {
-    return entries[item.sys.id] || {}
+    if (entries[item.sys.id]) {
+      entries[item.sys.id].id = item.sys.id
+      return entries[item.sys.id]
+     } else {
+       return {}
+     }
   }
 }
 

--- a/src/contentful-response-parser.js
+++ b/src/contentful-response-parser.js
@@ -54,7 +54,12 @@ const generateEntriesObject = (data, assets) => {
 
 const resolveLink = (item, assets, entries) => {
   if (item.sys.linkType === 'Asset') {
-    return assets[item.sys.id] || {}
+    if (assets[item.sys.id]) {
+      assets[item.sys.id].id = item.sys.id
+      return assets[item.sys.id]
+     } else {
+       return {}
+     }
   } else if (item.sys.linkType === 'Entry') {
     if (entries[item.sys.id]) {
       entries[item.sys.id].id = item.sys.id


### PR DESCRIPTION
This is a small change to copy the id out of sys into the parsed objects. This makes it easier to look up a particular contentful entity later based on its id.

I tested this locally and it seems to work as expected. I've only tried entities and referenced entities. I haven't checked assets. (I think that is the correct terminology. I'm new to contentful.)

If I've implemented this in a bad way feel free to let me know and I'll fix it up.
